### PR TITLE
feat: defi ohlcv endpoint

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+export enum TIME_FROM_AGO {
+  ONE_HOUR = 'ONE_HOUR',
+  ONE_DAY = 'ONE_DAY',
+  ONE_MONTH = 'ONE_MONTH',
+  SIX_MONTHS = 'SIX_MONTHS',
+  ONE_WEEK = 'ONE_WEEK',
+  ONE_YEAR = 'ONE_YEAR',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ app.get('/defi/history_price', async ({ env, req, text, executionCtx }) => {
       count++;
       if (count < maxTries) {
         return await callAPI(request, cache, executionCtx);
+      } else {
+        return new Response('Failed to fetch');
       }
     }
   }
@@ -120,6 +122,8 @@ app.get('/defi/*', async ({ env, req, text, executionCtx }) => {
       count++;
       if (count < maxTries) {
         return await callAPI(request, cache, executionCtx);
+      } else {
+        return new Response('Failed to fetch');
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { BlankSchema } from 'hono/types';
 import { cors } from 'hono/cors';
-import { callAPI } from './utils';
+import { callAPI, computeTimeAgo } from './utils';
+import { TIME_FROM_AGO } from './constants';
 
 const app = new Hono<
   {
@@ -46,6 +47,64 @@ app.get('/defi/history_price', async ({ env, req, text, executionCtx }) => {
   });
 
   const url = `https://public-api.birdeye.so/defi/history_price?${params.toString()}`;
+
+  const request = new Request(url, {
+    headers: new Headers({
+      'X-API-KEY': BIRDEYE_API_KEY || '',
+    }),
+  });
+
+  let cache = caches.default;
+  const cached = await cache.match(request);
+
+  if (cached) {
+    console.log('cached');
+    return new Response(cached.body);
+  } else {
+    try {
+      return await callAPI(request, cache, executionCtx);
+    } catch (error) {
+      console.log({ error });
+    }
+  }
+});
+
+app.get('/defi/ohlcv/*', async ({ env, req, text, executionCtx }) => {
+  const { BIRDEYE_API_KEY } = env;
+  if (!BIRDEYE_API_KEY) {
+    throw new Error('BIRDEYE_API_KEY is not set');
+  }
+
+  const timeTo = req.query()['time_to'];
+  const timeAgo = req.query()['time_ago'];
+  const roundEpoch = req.query()['round_epoch'];
+
+  if (!timeTo) {
+    throw new Error('time_to is required');
+  }
+
+  if (!timeAgo || !(timeAgo in TIME_FROM_AGO)) {
+    throw new Error('time_ago is required or invalid');
+  }
+
+  if (!roundEpoch) {
+    throw new Error('round_epoch is required');
+  }
+
+  const roundedTimeTo = Math.floor(+timeTo / +roundEpoch) * +roundEpoch;
+  const timefrom = computeTimeAgo(roundedTimeTo, timeAgo as TIME_FROM_AGO);
+
+  const params = new URLSearchParams({
+    ...req.query(),
+    time_from: timefrom.toString(),
+    time_to: roundedTimeTo.toString(),
+  });
+
+  // clean up params
+  params.delete('time_ago');
+  params.delete('round_epoch');
+
+  const url = `https://public-api.birdeye.so${req.path}?${params.toString()}`;
 
   const request = new Request(url, {
     headers: new Headers({

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ app.get('/defi/ohlcv/*', async ({ env, req, text, executionCtx }) => {
 
   const timeTo = req.query()['time_to'];
   const timeAgo = req.query()['time_ago'];
-  const roundEpoch = req.query()['round_epoch'];
+  const roundOffEpoch = req.query()['round_off_epoch'];
 
   if (!timeTo) {
     throw new Error('time_to is required');
@@ -87,11 +87,11 @@ app.get('/defi/ohlcv/*', async ({ env, req, text, executionCtx }) => {
     throw new Error('time_ago is required or invalid');
   }
 
-  if (!roundEpoch) {
+  if (!roundOffEpoch) {
     throw new Error('round_epoch is required');
   }
 
-  const roundedTimeTo = Math.floor(+timeTo / +roundEpoch) * +roundEpoch;
+  const roundedTimeTo = Math.floor(+timeTo / +roundOffEpoch) * +roundOffEpoch;
   const timefrom = computeTimeAgo(roundedTimeTo, timeAgo as TIME_FROM_AGO);
 
   const params = new URLSearchParams({
@@ -102,10 +102,11 @@ app.get('/defi/ohlcv/*', async ({ env, req, text, executionCtx }) => {
 
   // clean up params
   params.delete('time_ago');
-  params.delete('round_epoch');
+  params.delete('round_off_epoch');
 
   const url = `https://public-api.birdeye.so${req.path}?${params.toString()}`;
 
+  console.log({ url });
   const request = new Request(url, {
     headers: new Headers({
       'X-API-KEY': BIRDEYE_API_KEY || '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,27 +75,29 @@ app.get('/defi/ohlcv/*', async ({ env, req, text, executionCtx }) => {
     throw new Error('BIRDEYE_API_KEY is not set');
   }
 
-  const timeTo = req.query()['time_to'];
-  const timeAgo = req.query()['time_ago'];
-  const roundOffEpoch = req.query()['round_off_epoch'];
+  const query = req.query();
+  const { time_to: timeTo, time_ago: timeAgo, round_off_epoch: roundOffEpoch, time_from } = query;
 
   if (!timeTo) {
     throw new Error('time_to is required');
   }
 
-  if (!timeAgo || !(timeAgo in TIME_FROM_AGO)) {
-    throw new Error('time_ago is required or invalid');
-  }
+  // we do time_from to be backward compatible
+  if (!time_from) {
+    if (!timeAgo || !(timeAgo in TIME_FROM_AGO)) {
+      throw new Error('time_ago is required or invalid');
+    }
 
-  if (!roundOffEpoch) {
-    throw new Error('round_epoch is required');
+    if (!roundOffEpoch) {
+      throw new Error('round_epoch is required');
+    }
   }
 
   const roundedTimeTo = Math.floor(+timeTo / +roundOffEpoch) * +roundOffEpoch;
-  const timefrom = computeTimeAgo(roundedTimeTo, timeAgo as TIME_FROM_AGO);
+  const timefrom = time_from || computeTimeAgo(roundedTimeTo, timeAgo as TIME_FROM_AGO);
 
   const params = new URLSearchParams({
-    ...req.query(),
+    ...query,
     time_from: timefrom.toString(),
     time_to: roundedTimeTo.toString(),
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+const DEFAULT_TTL_IN_SECONDS = 60;
+
+export const callAPI = async (request: Request, cache: Cache, executionCtx: ExecutionContext) => {
+  const resp = await fetch(request);
+
+  if (resp.status === 200) {
+    const modifiedResp = new Response(resp.body, resp);
+    modifiedResp.headers.set('Cache-Control', `public, max-age=${DEFAULT_TTL_IN_SECONDS}`);
+
+    // save cache
+    executionCtx.waitUntil(cache.put(request, modifiedResp.clone()));
+    return modifiedResp;
+  } else {
+    return resp;
+  }
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { TIME_FROM_AGO } from './constants';
+
 const DEFAULT_TTL_IN_SECONDS = 60;
 
 export const callAPI = async (request: Request, cache: Cache, executionCtx: ExecutionContext) => {
@@ -13,4 +15,24 @@ export const callAPI = async (request: Request, cache: Cache, executionCtx: Exec
   } else {
     return resp;
   }
+};
+
+export const computeTimeAgo = (time: number, timeAgo: TIME_FROM_AGO) => {
+  let secondsToSubtract = 0;
+
+  if (timeAgo === TIME_FROM_AGO.ONE_HOUR) {
+    secondsToSubtract = 3600;
+  } else if (timeAgo === TIME_FROM_AGO.ONE_DAY) {
+    secondsToSubtract = 86400;
+  } else if (timeAgo === TIME_FROM_AGO.ONE_WEEK) {
+    secondsToSubtract = 604800;
+  } else if (timeAgo === TIME_FROM_AGO.ONE_MONTH) {
+    secondsToSubtract = 2628000;
+  } else if (timeAgo === TIME_FROM_AGO.SIX_MONTHS) {
+    secondsToSubtract = 15768000;
+  } else if (timeAgo === TIME_FROM_AGO.ONE_YEAR) {
+    secondsToSubtract = 31536000;
+  }
+
+  return time - secondsToSubtract;
 };


### PR DESCRIPTION
1. this endpoint handles 2 endpoint from the FE. `/defi/ohlcv` and `/defi/ohlcv/base_quote`

this endpoint introduces 2 new params from the FE. 
1. `time_ago` to compute `time_from` from the API. instead of FE passing it in 
2. `round_off_epoch` that dictates how much off the timestamp we want to round off 

---

on the FE, endpoint `/defi/ohlcv` is being consumed by value average, and this graph does not need to be constantly called as it's not real time data sensitive. we will cache this every 5 minutes. 

---
on the FE, endpoint `/defi/ohlcv/base_quote` is being consumed by limit order, and it's being called every 10 seconds. we set the `round_off_epoch` to 10 seconds
![CleanShot 2024-06-14 at 12  13 38@2x](https://github.com/jup-ag/birdeye-cache-proxy/assets/31162981/6bac7555-4439-45b8-b89f-598226b4a908)



